### PR TITLE
Add settings screen and chat preferences

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,11 +7,13 @@ import { ActivityIndicator, TouchableOpacity, View } from 'react-native';
 
 import { AuthProvider, useAuth } from './src/context/AuthContext';
 import { FollowProvider } from './src/context/FollowContext';
+import { PreferencesProvider } from './src/context/PreferencesContext';
 import { ThemeProvider, useTheme } from './src/context/ThemeContext';
 import FollowedScreen from './src/screens/FollowedScreen';
 import HomeScreen from './src/screens/HomeScreen';
 import LoginScreen from './src/screens/LoginScreen';
 import SearchScreen from './src/screens/SearchScreen';
+import SettingsScreen from './src/screens/SettingsScreen';
 import StreamScreen from './src/screens/StreamScreen';
 import { RootStackParamList } from './src/types';
 
@@ -21,12 +23,12 @@ const Tab = createBottomTabNavigator<TabParamList>();
 type TabParamList = {
   Home: undefined;
   Followed: undefined;
+  Settings: undefined;
 };
 
 function HomeTabs() {
-  const { theme, colors, toggleTheme } = useTheme();
+  const { colors } = useTheme();
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
-  const { signOut } = useAuth();
 
   return (
     <Tab.Navigator
@@ -38,6 +40,8 @@ function HomeTabs() {
             iconName = focused ? 'home' : 'home-outline';
           } else if (route.name === 'Followed') {
             iconName = focused ? 'heart' : 'heart-outline';
+          } else if (route.name === 'Settings') {
+            iconName = focused ? 'settings' : 'settings-outline';
           }
 
           return <Ionicons name={iconName} size={size} color={color} />;
@@ -54,16 +58,6 @@ function HomeTabs() {
           shadowColor: colors.shadow,
         },
         headerTintColor: colors.text,
-        headerRight: () => (
-          <View style={{ flexDirection: 'row' }}>
-            <TouchableOpacity onPress={signOut} style={{ marginRight: 15 }}>
-              <Ionicons name="log-out-outline" size={24} color={colors.text} />
-            </TouchableOpacity>
-            <TouchableOpacity onPress={toggleTheme} style={{ marginRight: 15 }}>
-              <Ionicons name={theme === 'light' ? 'moon' : 'sunny'} size={24} color={colors.text} />
-            </TouchableOpacity>
-          </View>
-        ),
       })}>
       <Tab.Screen
         name="Home"
@@ -76,21 +70,12 @@ function HomeTabs() {
                 style={{ marginRight: 15 }}>
                 <Ionicons name="search" size={24} color={colors.text} />
               </TouchableOpacity>
-              <TouchableOpacity onPress={signOut} style={{ marginRight: 15 }}>
-                <Ionicons name="log-out-outline" size={24} color={colors.text} />
-              </TouchableOpacity>
-              <TouchableOpacity onPress={toggleTheme} style={{ marginRight: 15 }}>
-                <Ionicons
-                  name={theme === 'light' ? 'moon' : 'sunny'}
-                  size={24}
-                  color={colors.text}
-                />
-              </TouchableOpacity>
             </View>
           ),
         }}
       />
       <Tab.Screen name="Followed" component={FollowedScreen} />
+      <Tab.Screen name="Settings" component={SettingsScreen} />
     </Tab.Navigator>
   );
 }
@@ -155,7 +140,9 @@ export default function App() {
       <AuthProvider>
         <NavigationContainer>
           <FollowProvider>
-            <AppContent />
+            <PreferencesProvider>
+              <AppContent />
+            </PreferencesProvider>
           </FollowProvider>
         </NavigationContainer>
       </AuthProvider>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -9,6 +9,7 @@ import {
   View,
 } from 'react-native';
 
+import { usePreferences } from '../context/PreferencesContext';
 import { useTheme } from '../context/ThemeContext';
 
 interface ChatViewProps {
@@ -148,6 +149,9 @@ function createRef() {
 
 export default function ChatView({ channelId, username }: ChatViewProps) {
   const { colors } = useTheme();
+  const {
+    chatPreferences: { enableSevenTvEmotes },
+  } = usePreferences();
   const socketRef = useRef<WebSocket | null>(null);
   const heartbeatRef = useRef<NodeJS.Timeout | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -312,8 +316,12 @@ export default function ChatView({ channelId, username }: ChatViewProps) {
   }, [channelId, teardownSocket, updateConnectionState]);
 
   useEffect(() => {
-    loadEmotes();
-  }, [loadEmotes]);
+    if (enableSevenTvEmotes) {
+      loadEmotes();
+    } else {
+      setEmoteMap({});
+    }
+  }, [enableSevenTvEmotes, loadEmotes]);
 
   useEffect(() => {
     connectSocket();

--- a/src/context/PreferencesContext.tsx
+++ b/src/context/PreferencesContext.tsx
@@ -1,0 +1,102 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+const CHAT_PREFERENCES_STORAGE_KEY = '@kicklite/chat-preferences';
+
+export type ChatPreferences = {
+  enableSevenTvEmotes: boolean;
+};
+
+const DEFAULT_CHAT_PREFERENCES: ChatPreferences = {
+  enableSevenTvEmotes: true,
+};
+
+type PreferencesContextValue = {
+  chatPreferences: ChatPreferences;
+  setChatPreference: <K extends keyof ChatPreferences>(key: K, value: ChatPreferences[K]) => void;
+  toggleChatPreference: <K extends keyof ChatPreferences>(key: K) => void;
+};
+
+const PreferencesContext = createContext<PreferencesContextValue | undefined>(undefined);
+
+async function loadStoredChatPreferences(): Promise<ChatPreferences> {
+  try {
+    const storedValue = await AsyncStorage.getItem(CHAT_PREFERENCES_STORAGE_KEY);
+    if (!storedValue) {
+      return DEFAULT_CHAT_PREFERENCES;
+    }
+
+    const parsed = JSON.parse(storedValue);
+    if (parsed && typeof parsed === 'object') {
+      return {
+        ...DEFAULT_CHAT_PREFERENCES,
+        ...parsed,
+      } as ChatPreferences;
+    }
+  } catch (error) {
+    console.error('Error loading chat preferences:', error);
+  }
+
+  return DEFAULT_CHAT_PREFERENCES;
+}
+
+export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [chatPreferences, setChatPreferences] = useState<ChatPreferences>(DEFAULT_CHAT_PREFERENCES);
+
+  useEffect(() => {
+    let mounted = true;
+
+    loadStoredChatPreferences().then((stored) => {
+      if (mounted) {
+        setChatPreferences(stored);
+      }
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const persistChatPreferences = useCallback((next: ChatPreferences) => {
+    AsyncStorage.setItem(CHAT_PREFERENCES_STORAGE_KEY, JSON.stringify(next)).catch((error) => {
+      console.error('Error saving chat preferences:', error);
+    });
+  }, []);
+
+  const setChatPreference = useCallback<PreferencesContextValue['setChatPreference']>(
+    (key, value) => {
+      setChatPreferences((previous) => {
+        const next = { ...previous, [key]: value };
+        persistChatPreferences(next);
+        return next;
+      });
+    },
+    [persistChatPreferences]
+  );
+
+  const toggleChatPreference = useCallback<PreferencesContextValue['toggleChatPreference']>(
+    (key) => {
+      setChatPreferences((previous) => {
+        const next = { ...previous, [key]: !previous[key] } as ChatPreferences;
+        persistChatPreferences(next);
+        return next;
+      });
+    },
+    [persistChatPreferences]
+  );
+
+  const value = useMemo<PreferencesContextValue>(
+    () => ({ chatPreferences, setChatPreference, toggleChatPreference }),
+    [chatPreferences, setChatPreference, toggleChatPreference]
+  );
+
+  return <PreferencesContext.Provider value={value}>{children}</PreferencesContext.Provider>;
+};
+
+export function usePreferences() {
+  const context = useContext(PreferencesContext);
+  if (context === undefined) {
+    throw new Error('usePreferences must be used within a PreferencesProvider');
+  }
+  return context;
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
+
+import { useAuth } from '../context/AuthContext';
+import { usePreferences } from '../context/PreferencesContext';
+import { useTheme } from '../context/ThemeContext';
+
+export default function SettingsScreen() {
+  const { theme, colors, toggleTheme } = useTheme();
+  const { isAuthenticated, profile, signOut, signIn, loading } = useAuth();
+  const { chatPreferences, toggleChatPreference } = usePreferences();
+
+  const handleLogout = async () => {
+    if (!isAuthenticated || loading) {
+      return;
+    }
+    await signOut();
+  };
+
+  const handleLogin = async () => {
+    if (!loading) {
+      await signIn();
+    }
+  };
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={styles.content}>
+      <View style={[styles.section, { backgroundColor: colors.card, borderColor: colors.border }]}>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Appearance</Text>
+        <View style={[styles.row, { borderColor: colors.border }]}>
+          <View style={styles.rowTextContainer}>
+            <Text style={[styles.rowTitle, { color: colors.text }]}>Dark mode</Text>
+            <Text style={[styles.rowSubtitle, { color: colors.secondaryText }]}>
+              Use the dark theme.
+            </Text>
+          </View>
+          <Switch
+            accessibilityLabel="Toggle dark mode"
+            value={theme === 'dark'}
+            onValueChange={toggleTheme}
+            trackColor={{ false: colors.border, true: colors.primary }}
+            thumbColor={theme === 'dark' ? '#f4f3f4' : '#ffffff'}
+          />
+        </View>
+      </View>
+
+      <View style={[styles.section, { backgroundColor: colors.card, borderColor: colors.border }]}>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Account</Text>
+        <View style={[styles.row, { borderColor: colors.border }]}>
+          <View style={styles.rowTextContainer}>
+            <Text style={[styles.rowTitle, { color: colors.text }]}>Kick OAuth</Text>
+            <Text style={[styles.rowSubtitle, { color: colors.secondaryText }]}>
+              {isAuthenticated && profile ? `Connected as ${profile.username}` : 'Not connected'}
+            </Text>
+          </View>
+          <View
+            style={[
+              styles.statusBadge,
+              { backgroundColor: isAuthenticated ? colors.primary : colors.border },
+            ]}>
+            <Text
+              style={[
+                styles.statusText,
+                { color: isAuthenticated ? '#ffffff' : colors.secondaryText },
+              ]}>
+              {isAuthenticated ? 'Connected' : 'Offline'}
+            </Text>
+          </View>
+        </View>
+        <TouchableOpacity
+          style={[
+            styles.button,
+            {
+              backgroundColor: isAuthenticated ? colors.error : colors.primary,
+              opacity: loading ? 0.6 : 1,
+            },
+          ]}
+          disabled={loading}
+          onPress={isAuthenticated ? handleLogout : handleLogin}>
+          <Text style={styles.buttonText}>{isAuthenticated ? 'Log out' : 'Log in with Kick'}</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={[styles.section, { backgroundColor: colors.card, borderColor: colors.border }]}>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Chat preferences</Text>
+        <View style={[styles.row, { borderColor: colors.border }]}>
+          <View style={styles.rowTextContainer}>
+            <Text style={[styles.rowTitle, { color: colors.text }]}>7TV emotes</Text>
+            <Text style={[styles.rowSubtitle, { color: colors.secondaryText }]}>
+              Show 7TV emotes in chat.
+            </Text>
+          </View>
+          <Switch
+            accessibilityLabel="Toggle 7TV emotes"
+            value={chatPreferences.enableSevenTvEmotes}
+            onValueChange={() => toggleChatPreference('enableSevenTvEmotes')}
+            trackColor={{ false: colors.border, true: colors.primary }}
+            thumbColor={chatPreferences.enableSevenTvEmotes ? '#f4f3f4' : '#ffffff'}
+          />
+        </View>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+  },
+  section: {
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 24,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  rowTextContainer: {
+    flex: 1,
+    paddingRight: 12,
+  },
+  rowTitle: {
+    fontSize: 16,
+    fontWeight: '500',
+    marginBottom: 4,
+  },
+  rowSubtitle: {
+    fontSize: 14,
+  },
+  statusBadge: {
+    borderRadius: 12,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+  },
+  statusText: {
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+  button: {
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  buttonText: {
+    color: '#ffffff',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- add a dedicated settings screen with appearance, account, and chat preference controls
- persist chat preference toggles via a new context backed by AsyncStorage and respect the 7TV option in chat
- extend the tab navigator with a Settings tab and share the preferences provider across the app

## Testing
- npm run lint *(fails: existing lint/prettier warnings in repository)*

------
https://chatgpt.com/codex/tasks/task_b_68d7672d61b08327be53486b182e2172