### PR TITLE
Secure Typesense search key handling

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,13 +59,15 @@ cd KickLiteApp
 npm install
 ```
 
-3. Start the development server:
+3. Configure environment variables (see [Environment Configuration](#environment-configuration)).
+
+4. Start the development server:
 
 ```bash
 npm start
 ```
 
-4. Run on your device:
+5. Run on your device:
 
 - Scan the QR code with Expo Go (Android)
 - Scan the QR code with Camera app (iOS)
@@ -83,7 +85,8 @@ src/
 │   ├── SearchScreen.tsx
 │   └── FollowedScreen.tsx
 ├── services/
-│   └── api.ts
+│   ├── api.ts
+│   └── search.ts
 ├── context/
 │   ├── ThemeContext.tsx
 │   └── FollowContext.tsx
@@ -122,6 +125,20 @@ src/
 - Thumbnail previews for live channels
 - Quick access to streams
 
+## Environment Configuration
+
+| Variable | Description |
+| -------- | ----------- |
+| `EXPO_PUBLIC_TYPESENSE_SEARCH_KEY` | Read-only Typesense search key used for local development builds. Required for the search screen. |
+
+Create a `.env` file (or configure your preferred secrets manager) and export the variable before starting Expo:
+
+```bash
+EXPO_PUBLIC_TYPESENSE_SEARCH_KEY=your_typesense_search_key_here
+```
+
+If the variable is missing the app will surface an informative error. This prevents accidentally running a build with a compromised or undefined key.
+
 ## API Integration
 
 The app uses the following Kick.com API endpoints:
@@ -129,6 +146,8 @@ The app uses the following Kick.com API endpoints:
 - Channel Info: `https://kick.com/api/v2/channels/{username}`
 - Live Streams: `https://kick.com/stream/livestreams/tr`
 - Search: `https://search.kick.com/multi_search`
+
+For production builds, proxy search requests through a secure backend (e.g., a serverless function or API gateway) so the mobile app never bundles private Typesense keys. After moving the key server-side, regenerate the compromised search key in Typesense and store only the new server-side credential.
 
 ## Contributing
 

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,51 @@
+import 'dotenv/config';
+import { ExpoConfig, ConfigContext } from 'expo/config';
+
+const baseConfig: ExpoConfig = {
+  name: 'KickLiteApp',
+  slug: 'KickLiteApp',
+  version: '1.0.0',
+  web: {
+    favicon: './assets/favicon.png',
+  },
+  experiments: {
+    tsconfigPaths: true,
+  },
+  plugins: [],
+  orientation: 'portrait',
+  icon: './assets/icon.png',
+  userInterfaceStyle: 'light',
+  splash: {
+    image: './assets/splash.png',
+    resizeMode: 'contain',
+    backgroundColor: '#ffffff',
+  },
+  assetBundlePatterns: ['**/*'],
+  ios: {
+    supportsTablet: true,
+  },
+  android: {
+    package: 'com.kicklite.app',
+    versionCode: 1,
+    adaptiveIcon: {
+      foregroundImage: './assets/adaptive-icon.png',
+      backgroundColor: '#ffffff',
+    },
+    permissions: ['INTERNET'],
+  },
+  extra: {
+    eas: {
+      projectId: '3413d430-b93a-4acc-9d48-d3f7e6cb892a',
+    },
+  },
+};
+
+export default ({ config }: ConfigContext): ExpoConfig => ({
+  ...baseConfig,
+  ...config,
+  extra: {
+    ...baseConfig.extra,
+    ...config.extra,
+    typesenseSearchKey: process.env.EXPO_PUBLIC_TYPESENSE_SEARCH_KEY,
+  },
+});

--- a/src/services/search.ts
+++ b/src/services/search.ts
@@ -1,0 +1,63 @@
+import Constants from 'expo-constants';
+
+export interface ChannelSearchResult {
+  username: string;
+  followers_count: number;
+  is_live: boolean;
+  verified: boolean;
+}
+
+const TYPESENSE_SEARCH_URL = 'https://search.kick.com/multi_search';
+const MISSING_KEY_ERROR =
+  'Missing Typesense search key. Set EXPO_PUBLIC_TYPESENSE_SEARCH_KEY in your environment before running the app.';
+
+const getTypesenseSearchKey = (): string => {
+  const extra = (Constants.expoConfig ?? Constants.manifest)?.extra as
+    | { typesenseSearchKey?: string }
+    | undefined;
+
+  const key = extra?.typesenseSearchKey;
+
+  if (!key) {
+    throw new Error(MISSING_KEY_ERROR);
+  }
+
+  return key;
+};
+
+export const searchChannels = async (query: string): Promise<ChannelSearchResult[]> => {
+  if (!query.trim()) {
+    return [];
+  }
+
+  const apiKey = getTypesenseSearchKey();
+
+  const response = await fetch(TYPESENSE_SEARCH_URL, {
+    method: 'POST',
+    headers: {
+      'content-type': 'text/plain;charset=UTF-8',
+      'x-typesense-api-key': apiKey,
+    },
+    body: JSON.stringify({
+      searches: [
+        { preset: 'category_search', q: query },
+        { preset: 'channel_search', q: query },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Search request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+
+  const channelHits = data?.results?.[1]?.hits ?? [];
+
+  return channelHits.map((hit: any) => ({
+    username: hit.document?.username,
+    followers_count: hit.document?.followers_count ?? 0,
+    is_live: Boolean(hit.document?.is_live),
+    verified: Boolean(hit.document?.verified),
+  }));
+};


### PR DESCRIPTION
## Summary
- load the Typesense search key from Expo config via a new app.config.ts
- centralize channel search logic in a service that validates the key and request status
- document the new environment variable and secure key management guidance in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d7694b51548327914d5284dbd69985