### PR TITLE
Enable picture-in-picture playback for streams

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,7 +22,10 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "infoPlist": {
+        "UIBackgroundModes": ["audio", "picture-in-picture"]
+      }
     },
     "android": {
       "package": "com.kicklite.app",
@@ -33,7 +36,8 @@
       },
       "permissions": [
         "INTERNET"
-      ]
+      ],
+      "supportsPictureInPicture": true
     },
     "extra": {
       "eas": {


### PR DESCRIPTION
## Summary
- request the native picture-in-picture player when the app backgrounds and the stream is actively playing
- track playback status to guard PiP requests and surface compatibility errors
- configure the Android and iOS manifests to advertise picture-in-picture support

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d774cde2e083279a1399da8f4e216d