### PR TITLE
Enable background audio playback for streams

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,7 @@ A React Native mobile application for watching Kick.com live streams. Built with
 - 💬 Native Kick chat powered by WebSockets with optional 7TV emotes (toggle in Settings)
 - 🌓 Dark/Light theme support
 - 📱 Picture-in-Picture support (iOS)
+- 🎧 Background audio playback while locked or in other apps
 - 📺 Fullscreen mode with automatic orientation
 - 🔄 Pull-to-refresh functionality
 
@@ -109,6 +110,7 @@ src/
 
 - Live stream playback with native controls
 - Picture-in-Picture support on iOS
+- Background audio playback so streams continue when switching apps or locking the device
 - Native chat rendering with Kick's real-time WebSocket API
 - Optional 7TV emote rendering toggle available under Settings → Chat Preferences
 - Follow/Unfollow streamers

--- a/app.json
+++ b/app.json
@@ -37,7 +37,8 @@
       "permissions": [
         "INTERNET"
       ],
-      "supportsPictureInPicture": true
+      "supportsPictureInPicture": true,
+      "playbackCategory": "playback"
     },
     "extra": {
       "eas": {


### PR DESCRIPTION
## Summary
- configure the stream screen to enable background audio playback and resume previous audio mode on unmount
- gate playback until audio configuration completes to ensure background audio settings apply before playing
- declare background audio capabilities for iOS and Android and document the new behavior in the README

## Testing
- npm run lint *(fails with existing formatting warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d7794627988327bd0ac6cac2ed6695