### PR TITLE
Configure custom Kick OAuth redirect scheme

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -5,6 +5,7 @@ const baseConfig: ExpoConfig = {
   name: 'KickLiteApp',
   slug: 'KickLiteApp',
   version: '1.0.0',
+  scheme: 'kicklite',
   web: {
     favicon: './assets/favicon.png',
   },

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AuthSessionResult, makeRedirectUri, startAsync } from 'expo-auth-session';
+import Constants from 'expo-constants';
 import React, {
   createContext,
   useCallback,
@@ -278,9 +279,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setError(null);
 
     try {
+      const isExpoHosted = Constants.appOwnership === 'expo';
+      const useProxy = Platform.OS === 'web' ? false : isExpoHosted;
       const redirectUri = makeRedirectUri({
         path: 'auth/kick',
-        useProxy: Platform.OS !== 'web',
+        useProxy,
+        scheme: useProxy ? undefined : 'kicklite',
       });
 
       const params = new URLSearchParams({


### PR DESCRIPTION
## Summary
- add the `kicklite` deep link scheme so native builds can register the auth callback
- route native auth redirects through the custom scheme while keeping the Expo proxy for Expo Go

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d78758de208327be3ed852f4f9ae25