### PR TITLE
Preserve refresh errors during bootstrap cleanup

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -233,7 +233,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         }
       } catch (bootError) {
         console.error('Failed to restore session', bootError);
-        setError('Failed to restore session');
+        setError((current) => current ?? 'Failed to restore session');
         await AsyncStorage.multiRemove([TOKEN_STORAGE_KEY, PROFILE_STORAGE_KEY]);
         setTokens(null);
         setProfile(null);


### PR DESCRIPTION
## Summary
- prevent the auth bootstrap cleanup from overriding errors that were already recorded

## Testing
- not run (environment limitation)


------
https://chatgpt.com/codex/tasks/task_b_68d78a656f3083278f588e6d170f757c