### PR TITLE
Fix Tailwind content globs for NativeWind

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,9 +2,7 @@
 module.exports = {
   content: [
     './App.{js,ts,tsx}',
-    './components/**/*.{js,ts,tsx}',
-    './screens/**/*.{js,ts,tsx}',
-    './navigation/**/*.{js,ts,tsx}',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
 
   presets: [require('nativewind/preset')],


### PR DESCRIPTION
## Summary
- update Tailwind content globs to cover App.tsx and src directory
- remove outdated component/screen/navigation globs so NativeWind can pick up styles

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68d78e3a98c88327b333f9b72d032370