### PR TITLE
Separate auth bootstrap and pending indicators

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -82,9 +82,23 @@ function HomeTabs() {
 
 function AppContent() {
   const { colors } = useTheme();
-  const { isAuthenticated, loading, tokens } = useAuth();
+  const { isAuthenticated, tokens, bootstrapping, authPending } = useAuth();
 
-  if (loading && (isAuthenticated || tokens)) {
+  if (bootstrapping) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          alignItems: 'center',
+          backgroundColor: colors.background,
+        }}>
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (authPending && (isAuthenticated || tokens)) {
     return (
       <View
         style={{

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -5,8 +5,15 @@ import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
 
 const LoginScreen: React.FC = () => {
-  const { signIn, loading, error } = useAuth();
+  const { signIn, authPending, bootstrapping, error } = useAuth();
   const { colors } = useTheme();
+
+  const isDisabled = bootstrapping || authPending;
+  const buttonLabel = bootstrapping
+    ? 'Preparing…'
+    : authPending
+      ? 'Connecting…'
+      : 'Continue with Kick';
 
   return (
     <SafeAreaView style={[styles.safeArea, { backgroundColor: colors.background }]}>
@@ -22,18 +29,16 @@ const LoginScreen: React.FC = () => {
             styles.button,
             {
               backgroundColor: colors.primary,
-              opacity: loading || pressed ? 0.7 : 1,
+              opacity: isDisabled || pressed ? 0.7 : 1,
               borderColor: colors.border,
             },
           ]}
-          disabled={loading}
+          disabled={isDisabled}
           onPress={signIn}>
-          <Text style={[styles.buttonText, { color: '#ffffff' }]}>
-            {loading ? 'Connecting…' : 'Continue with Kick'}
-          </Text>
+          <Text style={[styles.buttonText, { color: '#ffffff' }]}>{buttonLabel}</Text>
         </Pressable>
 
-        {loading ? (
+        {authPending ? (
           <ActivityIndicator size="small" color={colors.primary} style={styles.activityIndicator} />
         ) : null}
       </View>


### PR DESCRIPTION
## Summary
- add dedicated bootstrapping and authPending flags to the auth context while keeping loading derived
- show the app-level spinner during bootstrap and only block login interactions while an auth request is pending
- update the login screen button state and label to respect the new auth status flags

## Testing
- npm run lint *(fails: existing repository-wide lint warnings about formatting and import order)*
- npx tsc --noEmit *(fails: existing type definition mismatches in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d790b04f288327a17b5f8330046315