### PR TITLE
Wrap app in SafeAreaProvider

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import { NavigationContainer, useNavigation } from '@react-navigation/native';
 import { createStackNavigator, StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
 import { ActivityIndicator, TouchableOpacity, View } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { AuthProvider, useAuth } from './src/context/AuthContext';
 import { FollowProvider } from './src/context/FollowContext';
@@ -150,16 +151,18 @@ function AppContent() {
 
 export default function App() {
   return (
-    <ThemeProvider>
-      <AuthProvider>
-        <NavigationContainer>
-          <FollowProvider>
-            <PreferencesProvider>
-              <AppContent />
-            </PreferencesProvider>
-          </FollowProvider>
-        </NavigationContainer>
-      </AuthProvider>
-    </ThemeProvider>
+    <SafeAreaProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <NavigationContainer>
+            <FollowProvider>
+              <PreferencesProvider>
+                <AppContent />
+              </PreferencesProvider>
+            </FollowProvider>
+          </NavigationContainer>
+        </AuthProvider>
+      </ThemeProvider>
+    </SafeAreaProvider>
   );
 }

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { ActivityIndicator, Pressable, SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';


### PR DESCRIPTION
## Summary
- wrap the application providers with SafeAreaProvider so the safe area context is available throughout the app
- update the login screen to consume SafeAreaView from react-native-safe-area-context

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d794a2cd488327be012a3eb373cc37