### PR TITLE
Reset chat state on channel change

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -316,6 +316,13 @@ export default function ChatView({ channelId, username }: ChatViewProps) {
   }, [channelId, teardownSocket, updateConnectionState]);
 
   useEffect(() => {
+    setMessages([]);
+    setLoading(true);
+    setError(null);
+    updateConnectionState('connecting');
+  }, [channelId, updateConnectionState]);
+
+  useEffect(() => {
     if (enableSevenTvEmotes) {
       loadEmotes();
     } else {


### PR DESCRIPTION
## Summary
- clear the chat message list when switching to a new channel
- reset loading and error state so the UI reflects the fresh channel connection

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68d8e039d65883279f13e515a9a6b906