### PR TITLE
Extend Typesense key lookup for Expo builds

### DIFF
--- a/src/services/search.ts
+++ b/src/services/search.ts
@@ -12,11 +12,20 @@ const MISSING_KEY_ERROR =
   'Missing Typesense search key. Set EXPO_PUBLIC_TYPESENSE_SEARCH_KEY in your environment before running the app.';
 
 const getTypesenseSearchKey = (): string => {
-  const extra = (Constants.expoConfig ?? Constants.manifest)?.extra as
+  const legacyExtra = (Constants.expoConfig ?? Constants.manifest)?.extra as
     | { typesenseSearchKey?: string }
     | undefined;
 
-  const key = extra?.typesenseSearchKey;
+  const configExtra = Constants.expoConfigExtra as
+    | { typesenseSearchKey?: string }
+    | undefined;
+
+  const envKey = process.env.EXPO_PUBLIC_TYPESENSE_SEARCH_KEY;
+
+  const key =
+    legacyExtra?.typesenseSearchKey ??
+    configExtra?.typesenseSearchKey ??
+    envKey;
 
   if (!key) {
     throw new Error(MISSING_KEY_ERROR);


### PR DESCRIPTION
## Summary
- read the Typesense search key from expoConfigExtra or the legacy manifest extra
- fall back to EXPO_PUBLIC_TYPESENSE_SEARCH_KEY so the key resolves across Expo environments

## Testing
- npx expo run:android --variant release *(fails: Android SDK not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d8e8ea0f9483278d0c11250dbe3e07