### PR TITLE
Ensure AuthSession prompt uses proxy when available

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -342,7 +342,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       const authResult = (await request.promptAsync(
         { authorizationEndpoint: KICK_AUTHORIZE_URL },
-        { redirectUri }
+        { useProxy, redirectUri }
       )) as AuthSessionResult & {
         params: Record<string, string | undefined>;
       };


### PR DESCRIPTION
## Summary
- add the `useProxy` flag to the AuthSession prompt options so managed builds use Expo's proxy

## Testing
- not run (requires Expo Go or device-specific environment)


------
https://chatgpt.com/codex/tasks/task_b_68d911dff7c0832785ce1f355b8b5b4c