### PR TITLE
Add WebView-based OAuth fallback for Expo Android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
+        "react-native-webview": "13.15.0",
         "react-native-worklets": "0.5.1"
       },
       "devDependencies": {
@@ -10942,6 +10943,20 @@
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.15.0.tgz",
+      "integrity": "sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
       },
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
+    "react-native-webview": "13.15.0",
     "react-native-worklets": "0.5.1"
   },
   "devDependencies": {

--- a/src/components/KickAuthModal.tsx
+++ b/src/components/KickAuthModal.tsx
@@ -1,0 +1,178 @@
+import type { AuthRequest, AuthSessionResult } from 'expo-auth-session';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { WebView } from 'react-native-webview';
+import type { WebViewNavigation } from 'react-native-webview/lib/WebViewTypes';
+
+interface KickAuthModalProps {
+  visible: boolean;
+  authorizeUrl: string | null;
+  redirectUri: string;
+  request: AuthRequest | null;
+  onComplete: (result: AuthSessionResult) => void;
+  onCancel: () => void;
+}
+
+const KickAuthModal: React.FC<KickAuthModalProps> = ({
+  visible,
+  authorizeUrl,
+  redirectUri,
+  request,
+  onComplete,
+  onCancel,
+}) => {
+  const hasCompletedRef = useRef(false);
+
+  useEffect(() => {
+    if (!visible) {
+      hasCompletedRef.current = false;
+    }
+  }, [visible]);
+
+  const handleClose = useCallback(() => {
+    if (!hasCompletedRef.current) {
+      onCancel();
+    }
+  }, [onCancel]);
+
+  const maybeHandleRedirect = useCallback(
+    (url?: string | null) => {
+      if (!request || !url) {
+        return false;
+      }
+
+      if (!redirectUri) {
+        return false;
+      }
+
+      if (url.startsWith(redirectUri)) {
+        if (!hasCompletedRef.current) {
+          hasCompletedRef.current = true;
+          onComplete(request.parseReturnUrl(url));
+        }
+        return true;
+      }
+
+      return false;
+    },
+    [onComplete, redirectUri, request]
+  );
+
+  const handleNavigationStateChange = useCallback(
+    (event: WebViewNavigation) => {
+      maybeHandleRedirect(event.url);
+    },
+    [maybeHandleRedirect]
+  );
+
+  const handleShouldStartLoadWithRequest = useCallback(
+    (event: WebViewNavigation) => {
+      if (maybeHandleRedirect(event.url)) {
+        return false;
+      }
+      return true;
+    },
+    [maybeHandleRedirect]
+  );
+
+  const renderLoading = useCallback(
+    () => (
+      <View style={styles.loader}>
+        <ActivityIndicator size="large" />
+      </View>
+    ),
+    []
+  );
+
+  const webViewSource = useMemo(() => {
+    if (!authorizeUrl) {
+      return null;
+    }
+
+    return { uri: authorizeUrl };
+  }, [authorizeUrl]);
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="fullScreen"
+      onRequestClose={handleClose}>
+      <SafeAreaView style={styles.container}>
+        <View style={styles.header}>
+          <Pressable onPress={handleClose} style={styles.closeButton}>
+            <Text style={styles.closeButtonText}>Cancel</Text>
+          </Pressable>
+          <Text style={styles.title}>Sign in with Kick</Text>
+          <View style={styles.headerSpacer} />
+        </View>
+
+        {webViewSource ? (
+          <WebView
+            source={webViewSource}
+            startInLoadingState
+            renderLoading={renderLoading}
+            onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+            onNavigationStateChange={handleNavigationStateChange}
+            style={styles.webView}
+          />
+        ) : (
+          <View style={styles.loader}>
+            <ActivityIndicator size="large" />
+          </View>
+        )}
+      </SafeAreaView>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: '#111',
+  },
+  title: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  closeButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+  },
+  closeButtonText: {
+    color: '#60a5fa',
+    fontSize: 16,
+  },
+  headerSpacer: {
+    width: 60,
+  },
+  webView: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  loader: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#000',
+  },
+});
+
+export default KickAuthModal;


### PR DESCRIPTION
## Summary
- add the react-native-webview dependency for presenting OAuth flows inside the app
- create a KickAuthModal component that hosts the OAuth WebView and reports completion or cancellation
- update AuthProvider to open the modal on Expo Android, handle modal state, and reuse existing token exchange logic

## Testing
- npx eslint src/components/KickAuthModal.tsx src/context/AuthContext.tsx

------
https://chatgpt.com/codex/tasks/task_b_68d91a9726408327a9d98db12cdf64c5